### PR TITLE
Fix typo in month abbreviation for December

### DIFF
--- a/src/prototype.js
+++ b/src/prototype.js
@@ -38,7 +38,7 @@ Date.prototype.setWeekEnd = function(offset) {
 };
 
 Date.prototype.getMonthAbbrev = function() {
-    const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dev"];
+    const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
     return months[this.getMonth()];
 }
 


### PR DESCRIPTION
As much as I enjoy 'Dev' as a pun for Devember, the actual abbreviation for December should be 'Dec'