### PR TITLE
Improve error feedback on sign-in

### DIFF
--- a/lib/TimeularApi.js
+++ b/lib/TimeularApi.js
@@ -80,7 +80,8 @@ class TimeularApi {
 
             request(options, (error, response) => {
                 if (error || (response.statusCode != 200 && response.statusCode != 201)) {
-                    reject(`Error on Timeular request '${endpoint}'. ${response.statusMessage}.`);
+                    const bodyMessage = (response?.body) ? JSON.parse(response.body).message : '';
+                    reject(`Error on Timeular request '${endpoint}'. ${response.statusMessage}. ${bodyMessage}`);
                 } else {
                     let value = JSON.parse(response.body);
 


### PR DESCRIPTION
This line of code is to improve the error feedback when dealing with login.

Before, the error was:
```
Error on Timeular request 'developer/sign-in'. Unauthorized.
```

With this change, now the error is:
```
Error on Timeular request 'developer/sign-in'. Unauthorized. You provided invalid apiKey/apiSecret pair
```